### PR TITLE
Add new MC-Market domain to URL whitelist

### DIFF
--- a/urlWhitelist.txt
+++ b/urlWhitelist.txt
@@ -14,6 +14,7 @@ bing.com
 birdflop.com
 bisecthosting.com
 bitbucket.org
+builtbybit.com
 bukkit.org
 cloudflare.com
 contabo.com


### PR DESCRIPTION
## Proposed Changes
- Fixed URL whitelist allowing MC-Market's old domain but blocking the new one
     - The URL whitelist contains the domain "mc-market.org." However, MC-Market has had its branding changed and now has the domain "builtbybit.com." As the old MC-Market domain is in this whitelist, it is logical for the new domain to also be added.
